### PR TITLE
adding --permanent-peer

### DIFF
--- a/terraform/docker-chef.sh
+++ b/terraform/docker-chef.sh
@@ -213,7 +213,7 @@ docker_svc_start () {
   # https://stackoverflow.com/questions/39297530/bash-use-variable-as-name-of-associative-array-when-calling-value
   svc=$(echo "$1"|tr '-' '_')
   image="$svc[image]"
-  supargs="$svc[supargs]"
+  supargs="$svc[supargs] --permanent-peer"
   env="$svc[env]"
 
   echo "Starting ${!image}"


### PR DESCRIPTION
This ensures that each service member keeps a member census state and that any member will not be excluded from the ring when attempting to re-join after having been shutdown.

Signed-off-by: Jeremy J. Miller <jm@chef.io>