### PR TITLE
Fixes for habitat remote supervisor (0.57+)

### DIFF
--- a/docker/CTL_SECRET
+++ b/docker/CTL_SECRET
@@ -1,0 +1,1 @@
+Owrwmex8X9MuoxrAP8Rw8cIOW40+xVU5ESLWxebHzlbT93AFoZsN66nxOD4i/a4+jPfAo+XmuFitx56+kimF9w==

--- a/docker/automate.yml
+++ b/docker/automate.yml
@@ -1,6 +1,6 @@
 # Configurable environment variables:
-# HAB_ORIGIN - denotes the docker origin (dockerhub ID)
-# VERSION -  the version identifier tag on the packages
+# AUTOMATE_DOCKER_ORIGIN - denotes the docker origin (dockerhub ID) or default to `chefdemo`
+# AUTOMATE_VERSION -  the version identifier tag on the postgresql and elasticsearch packages from the `chefdemo` docker origin
 # HOST_IP - the IP address of the docker host. 172.17.0.1 is commonly the docker0 interface which is fine
 # ENTERPRISE - the name of the Automate enterprise to create
 # ADMIN_PASSWORD - the initial password to set for the 'admin' user in the Automate UI
@@ -9,7 +9,7 @@
 version: '2.1'
 services:
   postgresql:
-    image: ${HAB_ORIGIN:-chefdemo}/postgresql:${VERSION:-current}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/postgresql:${AUTOMATE_VERSION:-stable}
     network_mode: host
     environment:
       HAB_POSTGRESQL: |
@@ -17,10 +17,11 @@ services:
         name = 'hab'
         password = 'chefrocks'
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - postgresql-data:/hab/svc/postgresql/data
 
   rabbitmq:
-    image: ${HAB_ORIGIN:-chefdemo}/rabbitmq:${VERSION:-current}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/rabbitmq:${AUTOMATE_VERSION:-stable}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --listen-gossip 0.0.0.0:9650
@@ -36,10 +37,11 @@ services:
         [rabbitmq.management]
         enabled = true
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - rabbitmq-data:/hab/svc/rabbitmq/data
 
   elasticsearch:
-    image: ${HAB_ORIGIN:-chefserverofficial}/elasticsearch5:${VERSION:-latest}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefserverofficial}/elasticsearch5:${AUTOMATE_VERSION:-latest}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --listen-gossip 0.0.0.0:9651
@@ -47,10 +49,11 @@ services:
     depends_on:
       - postgresql
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - elasticsearch-data:/hab/svc/elasticsearch/data
 
   logstash:
-    image: ${HAB_ORIGIN:-chefdemo}/logstash:${VERSION:-current}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/logstash:${AUTOMATE_VERSION:-stable}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind elasticsearch:elasticsearch5.default
@@ -59,9 +62,11 @@ services:
       --listen-http 0.0.0.0:9662
     depends_on:
       - postgresql
+    volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 
   workflow-server:
-    image: ${HAB_ORIGIN:-chefdemo}/workflow-server:${VERSION:-current}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/workflow-server:${AUTOMATE_VERSION:-stable}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind database:postgresql.default
@@ -81,11 +86,12 @@ services:
         [mlsa]
         accept = true
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - maintenance:/var/opt/delivery/delivery/etc
       - workflow-data:/hab/svc/workflow-server/data
 
   notifications:
-    image: ${HAB_ORIGIN:-chefdemo}/notifications:${VERSION:-current}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/notifications:${AUTOMATE_VERSION:-stable}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind elasticsearch:elasticsearch5.default
@@ -94,9 +100,11 @@ services:
       --listen-http 0.0.0.0:9664
     depends_on:
       - postgresql
+    volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 
   compliance:
-    image: ${HAB_ORIGIN:-chefdemo}/compliance:${VERSION:-current}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/compliance:${AUTOMATE_VERSION:-stable}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind elasticsearch:elasticsearch5.default
@@ -106,10 +114,11 @@ services:
     depends_on:
       - postgresql
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - compliance-data:/hab/svc/compliance/data
 
   automate-nginx:
-    image: ${HAB_ORIGIN:-chefdemo}/automate-nginx:${VERSION:-current}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/automate-nginx:${AUTOMATE_VERSION:-stable}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind compliance:compliance.default
@@ -127,6 +136,7 @@ services:
         [mlsa]
         accept = true
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - maintenance:/var/opt/delivery/delivery/etc
       - nginx-data:/hab/svc/automate-nginx/data
 

--- a/docker/chef-server.yml
+++ b/docker/chef-server.yml
@@ -1,6 +1,8 @@
 # Configurable environment variables:
-# HAB_ORIGIN - denotes the docker origin (dockerhub ID)
-# VERSION -  the version identifier tag on the packages
+# CHEF_SERVER_DOCKER_ORIGIN - denotes the docker origin (dockerhub ID) or default to `chefserverofficial`
+# AUTOMATE_DOCKER_ORIGIN - denotes the docker origin (dockerhub ID) or default to `chefdemo`
+# CHEF_SERVER_VERSION -  the version identifier tag on the Chef Server packages
+# AUTOMATE_VERSION -  the version identifier tag on the postgresql and elasticsearch packages from the `chefdemo` docker origin
 # HOST_IP - the IP address of the docker host. 172.17.0.1 is commonly the docker0 interface which is fine
 # AUTOMATE_ENABLED - enable the Automate data collector (true or false)
 # AUTOMATE_SERVER - the IP address or hostname of the Automate server
@@ -8,7 +10,7 @@
 version: '2.1'
 services:
   postgresql:
-    image: ${HAB_ORIGIN:-chefserverofficial}/postgresql
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/postgresql:${AUTOMATE_VERSION:-stable}
     network_mode: host
     environment:
       HAB_POSTGRESQL: |
@@ -16,10 +18,11 @@ services:
         name = 'hab'
         password = 'chefrocks'
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - postgresql-data:/hab/svc/postgresql/data
 
   chef-server-ctl:
-    image: ${HAB_ORIGIN:-chefserverofficial}/chef-server-ctl
+    image: ${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/chef-server-ctl:${CHEF_SERVER_VERSION:-latest}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --listen-gossip 0.0.0.0:9650
@@ -30,9 +33,11 @@ services:
         ip = '${HOST_IP:-172.17.0.1}'
         [secrets.data_collector]
         token = "${AUTOMATE_TOKEN:-93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506}"
+    volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 
   elasticsearch:
-    image: ${HAB_ORIGIN:-chefserverofficial}/elasticsearch5:${VERSION:-latest}
+    image: ${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/elasticsearch5:${AUTOMATE_VERSION:-stable}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --listen-gossip 0.0.0.0:9651
@@ -42,37 +47,44 @@ services:
         soft: 65536
         hard: 65536
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - elasticsearch-data:/hab/svc/elasticsearch/data
 
   oc_id:
-    image: ${HAB_ORIGIN:-chefserverofficial}/oc_id
+    image: ${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/oc_id:${CHEF_SERVER_VERSION:-latest}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind database:postgresql.default
       --bind chef-server-ctl:chef-server-ctl.default
       --listen-gossip 0.0.0.0:9652
       --listen-http 0.0.0.0:9662
+    volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 
   bookshelf:
-    image: ${HAB_ORIGIN:-chefserverofficial}/bookshelf
+    image: ${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/bookshelf:${CHEF_SERVER_VERSION:-latest}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind database:postgresql.default
       --bind chef-server-ctl:chef-server-ctl.default
       --listen-gossip 0.0.0.0:9653
       --listen-http 0.0.0.0:9663
+    volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 
   oc_bifrost:
-    image: ${HAB_ORIGIN:-chefserverofficial}/oc_bifrost
+    image: ${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/oc_bifrost:${CHEF_SERVER_VERSION:-latest}
     network_mode: host
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind database:postgresql.default
       --bind chef-server-ctl:chef-server-ctl.default
       --listen-gossip 0.0.0.0:9654
       --listen-http 0.0.0.0:9664
+    volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 
   oc_erchef:
-    image: ${HAB_ORIGIN:-chefserverofficial}/oc_erchef
+    image: ${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/oc_erchef:${CHEF_SERVER_VERSION:-latest}
     network_mode: host
     volumes:
       - erchef-data:/hab/svc/oc_erchef/data
@@ -90,13 +102,16 @@ services:
         enabled = ${AUTOMATE_ENABLED:-false}
         server = "${AUTOMATE_SERVER:-localhost}"
         port = 443
+    volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 
   chef-server-nginx:
-    image: ${HAB_ORIGIN:-chefserverofficial}/chef-server-nginx
+    image: ${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/chef-server-nginx:${CHEF_SERVER_VERSION:-latest}
     network_mode: host
     tty: true
     stdin_open: true
     volumes:
+      - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
       - nginx-data:/hab/svc/chef-server-nginx/data
     command: --peer ${HOST_IP:-172.17.0.1}
       --bind oc_erchef:oc_erchef.default

--- a/docker/chef-server.yml
+++ b/docker/chef-server.yml
@@ -102,6 +102,11 @@ services:
         enabled = ${AUTOMATE_ENABLED:-false}
         server = "${AUTOMATE_SERVER:-localhost}"
         port = 443
+        [chef_authn]
+        keygen_cache_workers = 2
+        keygen_cache_size = 10
+        keygen_start_size = 0
+        keygen_timeout = 20000
     volumes:
       - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
 

--- a/terraform/docker-chef.sh
+++ b/terraform/docker-chef.sh
@@ -225,6 +225,7 @@ docker_svc_start () {
     --name="${1}" \
     --env="HOME=/hab/svc/${1}/data" \
     --env="${!env:-ILOVECHEF=1}" \
+    --volume ${DATA_MOUNT:-/mnt/hab}/CTL_SECRET:/hab/sup/default/CTL_SECRET:ro \
     --volume ${DATA_MOUNT:-/mnt/hab}/passwd:/etc/passwd:ro \
     --volume ${DATA_MOUNT:-/mnt/hab}/group:/etc/group:ro \
     --volume ${DATA_MOUNT:-/mnt/hab}/${1}_svc:/hab/svc \

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -137,6 +137,10 @@ resource "null_resource" "provision_cluster" {
     content     = "${data.template_file.passwd.rendered}"
     destination = "${var.container_data_mount}/passwd"
   }
+  provisioner "file" {
+    content     = "${var.ctl_secret}"
+    destination = "${var.container_data_mount}/CTL_SECRET"
+  }
   provisioner "remote-exec" {
     inline = [
       "sudo chmod a+x /home/${var.container_username}/*sh",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -91,6 +91,11 @@ variable "container_gid" {
   description = "The group id used to set permission on the container host."
 }
 
+variable "ctl_secret" {
+  default     = "Owrwmex8X9MuoxrAP8Rw8cIOW40+xVU5ESLWxebHzlbT93AFoZsN66nxOD4i/a4+jPfAo+XmuFitx56+kimF9w=="
+  description = "The token used for communication between the hab cli and the habitat supervisor"
+}
+
 variable "container_data_mount" {
   default     = "/mnt/data"
   description = "The data mount created on each docker host."


### PR DESCRIPTION

in docker-compose files:
- [x] Create and mount the CTL_SECRET file needed in all containers after hab 0.57.  
- [x] unify origin and version environment variables with docker-chef.sh

in terraform-based files:
- [x] Create and mount the CTL_SECRET file needed in all containers after hab 0.57.  

Signed-off-by: Irving Popovetsky <irving@chef.io>