### PR TITLE
mixbag of fixes/features

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,19 +269,19 @@ workflow-server.default hook[health_check]:(HK): {"status":"pong","configuration
 
 As the `$USER_ID` user on the Automate host, run the following commands to apply an Automate license.
 
-First, copy the license to the host, and place it in `$DATA_MOUNT/workflow-server_svc/workflow-server/var/`
-Then, log into the `workflow-server` container
+First copy the license to the host and place it in `$DATA_MOUNT/workflow-server_svc/workflow-server/var/`
+Next, log into the `workflow-server` container.
 ```
 $ docker exec -it workflow-server bash
 ```
 
 Create and export an environment variable to contain the Supervisor CTL gateway port for this
-particular container
+particular container.
 ```
 $ export SUP_PORT=$($(hab pkg path core/curl)/bin/curl -s http://127.0.0.1:9631/butterfly | $(hab pkg path core/jq-static)/bin/jq '.service.list."workflow-server.default"[].service.sys.ctl_gateway_port' -e -c -M -r)
 ```
 
-Finally, use the `hab file upload ..` command to upload the license to the Habitat service
+Finally, use the `hab file upload ..` command to upload the license to the Habitat service.
 ```
 $ hab file upload workflow-server.default $(date +'%s') /hab/svc/workflow-server/var/delivery.license -r 127.0.0.1:$SUP_PORT
 » Uploading file /hab/svc/workflow-server/var/delivery.license to 1532653445 incarnation workflow-server.default
@@ -297,7 +297,7 @@ Due to the Remote Supervisor Control features introduced in Habitat 0.56.0 and t
 are setting unique Supervisor CTL Gateway ports for each service so they can all co-exist on one
 Docker Host, you must use the `--remote-sup IP:PORT` argument to `hab sup *` commands.
 
-For example, to run `hab sup status` on the `workflow-server` container, you can do so like this
+For example, to run `hab sup status` on the `workflow-server` container, you can do so like this:
 ```
 ~ $ export SUP_PORT=$($(hab pkg path core/curl)/bin/curl -s http://127.0.0.1:963
 1/butterfly | $(hab pkg path core/jq-static)/bin/jq '.service.list."workflow-ser
@@ -310,4 +310,3 @@ jeremymv2/workflow-server/1.8.0-dev/20180726192935  standalone  up     857      
 
 Note: You will need to replace `workflow-server.default` with `CONTAINER-NAME.default` for the other
 containers.
-

--- a/README.md
+++ b/README.md
@@ -264,3 +264,50 @@ workflow-server.default hook[health_check]:(HK): {"status":"pong","configuration
 "task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0},"rabbitmq":{"status":"pong","vhost_aliveness":{"status":
 "pong"},"node_health":{"status":"pong"}}}]}
 ```
+
+## Automate License
+
+As the `$USER_ID` user on the Automate host, run the following commands to apply an Automate license.
+
+First, copy the license to the host, and place it in `$DATA_MOUNT/workflow-server_svc/workflow-server/var/`
+Then, log into the `workflow-server` container
+```
+$ docker exec -it workflow-server bash
+```
+
+Create and export an environment variable to contain the Supervisor CTL gateway port for this
+particular container
+```
+$ export SUP_PORT=$($(hab pkg path core/curl)/bin/curl -s http://127.0.0.1:9631/butterfly | $(hab pkg path core/jq-static)/bin/jq '.service.list."workflow-server.default"[].service.sys.ctl_gateway_port' -e -c -M -r)
+```
+
+Finally, use the `hab file upload ..` command to upload the license to the Habitat service
+```
+$ hab file upload workflow-server.default $(date +'%s') /hab/svc/workflow-server/var/delivery.license -r 127.0.0.1:$SUP_PORT
+» Uploading file /hab/svc/workflow-server/var/delivery.license to 1532653445 incarnation workflow-server.default
+Ω Creating service file
+↑ Applying via peer 127.0.0.1:9635
+★ Uploaded file
+$
+```
+
+## Running `hab sup *` commands
+
+Due to the Remote Supervisor Control features introduced in Habitat 0.56.0 and the fact that we
+are setting unique Supervisor CTL Gateway ports for each service so they can all co-exist on one
+Docker Host, you must use the `--remote-sup IP:PORT` argument to `hab sup *` commands.
+
+For example, to run `hab sup status` on the `workflow-server` container, you can do so like this
+```
+~ $ export SUP_PORT=$($(hab pkg path core/curl)/bin/curl -s http://127.0.0.1:963
+1/butterfly | $(hab pkg path core/jq-static)/bin/jq '.service.list."workflow-ser
+ver.default"[].service.sys.ctl_gateway_port' -e -c -M -r)
+~ $ hab sup status --remote-sup 127.0.0.1:$SUP_PORT
+package                                             type        state  elapsed (s)  pid   group
+jeremymv2/workflow-server/1.8.0-dev/20180726192935  standalone  up     857          3777  workflow-server.default
+~ $
+```
+
+Note: You will need to replace `workflow-server.default` with `CONTAINER-NAME.default` for the other
+containers.
+

--- a/terraform/docker-chef.sh
+++ b/terraform/docker-chef.sh
@@ -272,7 +272,7 @@ stop_all () {
   rm -rf ${DATA_MOUNT:-/mnt/hab}/*_sup
 }
 
-tar_svcs() {
+tar_svc_logs() {
   arr=("$@")
 
   LOG_DIR="$(hostname -s)-$(date +'%Y%m%d%H%M%S')-logs"
@@ -304,14 +304,14 @@ gatherlogs_all () {
       exit 1
       ;;
   esac
-  tar_svcs "${array[@]}"
+  tar_svc_logs "${array[@]}"
   exit 0
 }
 
 gatherlogs_svc () {
   echo "Gathering logs for $SERVICE_TYPE $1"
   array=("$1")
-  tar_svcs "${array[@]}"
+  tar_svc_logs "${array[@]}"
   exit 0
 }
 start_all () {

--- a/terraform/docker-chef.sh
+++ b/terraform/docker-chef.sh
@@ -29,10 +29,13 @@ You must specify the following options:
  -s [automate|chef-server]           REQUIRED: Services type: Chef Server or Chef Automate
  -a [stop|start]                     REQUIRED: Action type: start or stop services
  -n [container name]                 OPTIONAL: The docker container name. Leaving blank implies ALL
+ -g [gather-logs]                    OPTIONAL: Save container logs to .gz
  -h                                  OPTIONAL: Print this help message
 
  ex. $0 -s chef-server -a start            # starts up all Chef Server services
  ex. $0 -s automate -a stop -n logstash    # stops Automate's logstash service
+ ex. $0 -s automate -g                     # saves all Automate container logs to .gz
+ ex. $0 -s chef-server -g -n postgresql    # saves Chef Server Postgresql logs to .gz
 
 "
 
@@ -45,7 +48,7 @@ if [ $# -eq 0 ]; then
   usage
 fi
 
-while getopts "s:a:n:h" opt; do
+while getopts "s:a:n:gh" opt; do
   case $opt in
     s)
       echo "Service type: $OPTARG"
@@ -58,6 +61,9 @@ while getopts "s:a:n:h" opt; do
     n)
       echo "Service name: $OPTARG"
       export SERVICE_NAME=$OPTARG
+      ;;
+    g)
+      export GATHER_LOGS=true
       ;;
     h)
       usage
@@ -86,7 +92,7 @@ postgresql["supargs"]=""
 
 declare -A elasticsearch
 elasticsearch["image"]="${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/elasticsearch5:${AUTOMATE_VERSION:-stable}"
-elasticsearch["supargs"]="--peer ${HOST_IP:-172.17.0.1} --listen-gossip 0.0.0.0:9651 --listen-http 0.0.0.0:9661"
+elasticsearch["supargs"]="--peer ${HOST_IP:-172.17.0.1} --listen-gossip 0.0.0.0:9651 --listen-http 0.0.0.0:9661 --listen-ctl 0.0.0.0:9633"
 elasticsearch["env"]="HAB_ELASTICSEARCH5=[runtime]
 heapsize = \"4g\"
 "
@@ -101,22 +107,22 @@ ssl_port = \"8443\"
 [secrets.data_collector]
 token = \"${AUTOMATE_TOKEN:-93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506}\"
 "
-chef_server_ctl["supargs"]="--peer ${HOST_IP:-172.17.0.1} --listen-gossip 0.0.0.0:9650 --listen-http 0.0.0.0:9660"
+chef_server_ctl["supargs"]="--peer ${HOST_IP:-172.17.0.1} --listen-gossip 0.0.0.0:9650 --listen-http 0.0.0.0:9660 --listen-ctl 0.0.0.0:9634"
 
 declare -A oc_id
 oc_id["image"]="${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/oc_id:${CHEF_SERVER_VERSION:-stable}"
 oc_id["env"]=""
-oc_id["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9652 --listen-http 0.0.0.0:9662"
+oc_id["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9652 --listen-http 0.0.0.0:9662 --listen-ctl 0.0.0.0:9635"
 
 declare -A bookshelf
 bookshelf["image"]="${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/bookshelf:${CHEF_SERVER_VERSION:-stable}"
 bookshelf["env"]=""
-bookshelf["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9653 --listen-http 0.0.0.0:9663"
+bookshelf["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9653 --listen-http 0.0.0.0:9663 --listen-ctl 0.0.0.0:9636"
 
 declare -A oc_bifrost
 oc_bifrost["image"]="${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/oc_bifrost:${CHEF_SERVER_VERSION:-stable}"
 oc_bifrost["env"]=""
-oc_bifrost["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9654 --listen-http 0.0.0.0:9664"
+oc_bifrost["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9654 --listen-http 0.0.0.0:9664 --listen-ctl 0.0.0.0:9637"
 
 declare -A oc_erchef
 oc_erchef["image"]="${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/oc_erchef:${CHEF_SERVER_VERSION:-stable}"
@@ -130,11 +136,11 @@ keygen_cache_size = 10
 keygen_start_size = 0
 keygen_timeout = 20000
 "
-oc_erchef["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind bookshelf:bookshelf.default --bind oc_bifrost:oc_bifrost.default --bind database:postgresql.default --bind elasticsearch:elasticsearch5.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9655 --listen-http 0.0.0.0:9665"
+oc_erchef["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind bookshelf:bookshelf.default --bind oc_bifrost:oc_bifrost.default --bind database:postgresql.default --bind elasticsearch:elasticsearch5.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9655 --listen-http 0.0.0.0:9665 --listen-ctl 0.0.0.0:9638"
 
 declare -A chef_server_nginx
 chef_server_nginx["image"]="${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/chef-server-nginx:${CHEF_SERVER_VERSION:-stable}"
-chef_server_nginx["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind oc_erchef:oc_erchef.default --bind oc_bifrost:oc_bifrost.default --bind oc_id:oc_id.default --bind bookshelf:bookshelf.default --bind elasticsearch:elasticsearch5.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9656 --listen-http 0.0.0.0:9666"
+chef_server_nginx["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind oc_erchef:oc_erchef.default --bind oc_bifrost:oc_bifrost.default --bind oc_id:oc_id.default --bind bookshelf:bookshelf.default --bind elasticsearch:elasticsearch5.default --bind chef-server-ctl:chef-server-ctl.default --listen-gossip 0.0.0.0:9656 --listen-http 0.0.0.0:9666 --listen-ctl 0.0.0.0:9639"
 chef_server_nginx["env"]='HAB_CHEF_SERVER_NGINX=
 access_log = "/dev/stdout"
 '
@@ -151,12 +157,12 @@ default_pass = 'chefrocks'
 [rabbitmq.management]
 enabled = true
 "
-rabbitmq["supargs"]="--peer ${HOST_IP:-172.17.0.1} --listen-gossip 0.0.0.0:9650 --listen-http 0.0.0.0:9660"
+rabbitmq["supargs"]="--peer ${HOST_IP:-172.17.0.1} --listen-gossip 0.0.0.0:9650 --listen-http 0.0.0.0:9660 --listen-ctl 0.0.0.0:9633"
 
 declare -A logstash
 #logstash["image"]="irvingpop/logstash"
 logstash["image"]="${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/logstash:${AUTOMATE_VERSION:-stable}"
-logstash["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind elasticsearch:elasticsearch5.default --bind rabbitmq:rabbitmq.default --listen-gossip 0.0.0.0:9652 --listen-http 0.0.0.0:9662"
+logstash["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind elasticsearch:elasticsearch5.default --bind rabbitmq:rabbitmq.default --listen-gossip 0.0.0.0:9652 --listen-http 0.0.0.0:9662 --listen-ctl 0.0.0.0:9634"
 logstash["env"]="HAB_LOGSTASH=
 java_heap_size=\"2g\"
 pipeline_batch_size=40
@@ -172,12 +178,12 @@ token = \"${AUTOMATE_TOKEN:-93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb
 [mlsa]
 accept = true
 "
-workflow_server["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind elasticsearch:elasticsearch5.default --bind rabbitmq:rabbitmq.default --listen-gossip 0.0.0.0:9653 --listen-http 0.0.0.0:9663"
+workflow_server["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind database:postgresql.default --bind elasticsearch:elasticsearch5.default --bind rabbitmq:rabbitmq.default --listen-gossip 0.0.0.0:9653 --listen-http 0.0.0.0:9663 --listen-ctl 0.0.0.0:9635"
 
 declare -A notifications
 notifications["image"]="${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/notifications:${AUTOMATE_VERSION:-stable}"
 notifications["env"]=""
-notifications["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind elasticsearch:elasticsearch5.default --bind rabbitmq:rabbitmq.default --listen-gossip 0.0.0.0:9654 --listen-http 0.0.0.0:9664"
+notifications["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind elasticsearch:elasticsearch5.default --bind rabbitmq:rabbitmq.default --listen-gossip 0.0.0.0:9654 --listen-http 0.0.0.0:9664 --listen-ctl 0.0.0.0:9636"
 
 declare -A compliance
 compliance["image"]="${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/compliance:${AUTOMATE_VERSION:-stable}"
@@ -186,7 +192,7 @@ host = \"0.0.0.0\"
 [profiles]
 secrets_key = \"12345678901234567890123456789012\"
 "
-compliance["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind postgresql:postgresql.default --bind elasticsearch:elasticsearch5.default --bind workflow:workflow-server.default --listen-gossip 0.0.0.0:9655 --listen-http 0.0.0.0:9665"
+compliance["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind postgresql:postgresql.default --bind elasticsearch:elasticsearch5.default --bind workflow:workflow-server.default --listen-gossip 0.0.0.0:9655 --listen-http 0.0.0.0:9665 --listen-ctl 0.0.0.0:9637"
 
 declare -A automate_nginx
 automate_nginx["image"]="${AUTOMATE_DOCKER_ORIGIN:-chefdemo}/automate-nginx:${AUTOMATE_VERSION:-stable}"
@@ -196,7 +202,7 @@ ssl_port = ${PILOT_HTTPS_PORT:-8443}
 [mlsa]
 accept = true
 "
-automate_nginx["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind compliance:compliance.default --bind elasticsearch:elasticsearch5.default --bind workflow:workflow-server.default --bind notifications:notifications.default --listen-gossip 0.0.0.0:9656 --listen-http 0.0.0.0:9666"
+automate_nginx["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind compliance:compliance.default --bind elasticsearch:elasticsearch5.default --bind workflow:workflow-server.default --bind notifications:notifications.default --listen-gossip 0.0.0.0:9656 --listen-http 0.0.0.0:9666 --listen-ctl 0.0.0.0:9638"
 
 # Service functions
 #
@@ -266,6 +272,48 @@ stop_all () {
   rm -rf ${DATA_MOUNT:-/mnt/hab}/*_sup
 }
 
+tar_svcs() {
+  arr=("$@")
+
+  LOG_DIR="$(hostname -s)-$(date +'%Y%m%d%H%M%S')-logs"
+  mkdir $LOG_DIR
+
+  for svc in "${arr[@]}"; do
+    docker logs "$svc" > $LOG_DIR/$svc.log
+  done
+
+  LOG_GZ="$LOG_DIR.tar.gz"
+  tar czf $LOG_GZ $LOG_DIR
+  rm -rf $LOG_DIR
+  echo "Logs saved to $LOG_GZ"
+}
+
+
+
+gatherlogs_all () {
+  echo "Gathering logs for all $SERVICE_TYPE services.."
+  case "$1" in
+    chef-server)
+      array=("chef-server-nginx" "oc_erchef" "oc_id" "bookshelf" "oc_bifrost" "elasticsearch" "chef-server-ctl" "postgresql")
+      ;;
+    automate)
+      array=("automate-nginx" "workflow-server" "notifications" "compliance" "logstash" "rabbitmq" "elasticsearch" "postgresql")
+      ;;
+    *)
+      echo "not implemented"
+      exit 1
+      ;;
+  esac
+  tar_svcs "${array[@]}"
+  exit 0
+}
+
+gatherlogs_svc () {
+  echo "Gathering logs for $SERVICE_TYPE $1"
+  array=("$1")
+  tar_svcs "${array[@]}"
+  exit 0
+}
 start_all () {
   case "$1" in
     chef-server)
@@ -294,6 +342,19 @@ case "$SERVICE_TYPE" in
      usage
      ;;
   automate|chef-server)
+    case "$GATHER_LOGS" in
+      true)
+        case "$SERVICE_NAME" in
+          # optional service name
+          "")
+            gatherlogs_all "$SERVICE_TYPE"
+            ;;
+          *)
+            gatherlogs_svc "$SERVICE_NAME"
+            ;;
+        esac
+        ;;
+    esac
     # start or stop
     case "$SERVICE_ACTION" in
       stop)

--- a/terraform/group.tpl
+++ b/terraform/group.tpl
@@ -21,5 +21,5 @@ input:x:24:
 mail:x:34:
 nogroup:x:99:
 users:x:999:
-hab:x:42:hab:
+hab:x:42:
 ${container_username}:x:${container_gid}:


### PR DESCRIPTION
![woohoo](https://user-images.githubusercontent.com/1991696/43299458-ec420c0c-911f-11e8-8cbe-b8165b351d92.jpg)

* each container supervisor gets a `--listen-ctl` (Fixes the `[Err: 4] secret key mismatch` issue)
* gather logs feature added to `docker-chef.sh`
* `hab` group file entry corrected
* documentation on running `hab sup *` commands including Automate license file upload

```
[chef-dev-ux@ip-172-31-28-214 ~]$ ./docker-chef.sh -h
This is a control script for starting|stopping Chef Server and Chef Automate docker services.

You must specify the following options:
 -s [automate|chef-server]           REQUIRED: Services type: Chef Server or Chef Automate
 -a [stop|start]                     REQUIRED: Action type: start or stop services
 -n [container name]                 OPTIONAL: The docker container name. Leaving blank implies ALL
 -g [gather-logs]                    OPTIONAL: Save container logs to .gz
 -h                                  OPTIONAL: Print this help message

 ex. ./docker-chef.sh -s chef-server -a start            # starts up all Chef Server services
 ex. ./docker-chef.sh -s automate -a stop -n logstash    # stops Automate's logstash service
 ex. ./docker-chef.sh -s automate -g                     # saves all Automate container logs to .gz
 ex. ./docker-chef.sh -s chef-server -g -n postgresql    # saves Chef Server Postgresql logs to .gz


[chef-dev-ux@ip-172-31-28-214 ~]$ ./docker-chef.sh -s automate -g
Service type: automate
Gathering logs for all automate services..
Logs saved to ip-172-31-28-214-20180727025427-logs.tar.gz

[chef-dev-ux@ip-172-31-28-214 ~]$ tar tvf ip-172-31-28-214-20180727025427-logs.tar.gz
drwxrwxr-x chef-dev-ux/chef-dev-ux 0 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/
-rw-rw-r-- chef-dev-ux/chef-dev-ux 5466 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/automate-nginx.log
-rw-rw-r-- chef-dev-ux/chef-dev-ux 45806 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/workflow-server.log
-rw-rw-r-- chef-dev-ux/chef-dev-ux  3337 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/notifications.log
-rw-rw-r-- chef-dev-ux/chef-dev-ux  4571 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/compliance.log
-rw-rw-r-- chef-dev-ux/chef-dev-ux  2814 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/logstash.log
-rw-rw-r-- chef-dev-ux/chef-dev-ux  4515 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/rabbitmq.log
-rw-rw-r-- chef-dev-ux/chef-dev-ux  5805 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/elasticsearch.log
-rw-rw-r-- chef-dev-ux/chef-dev-ux  2001 2018-07-27 02:54 ip-172-31-28-214-20180727025427-logs/postgresql.log
[chef-dev-ux@ip-172-31-28-214 ~]$
```