### PR TITLE
Fix data mount for elasticsearch5

### DIFF
--- a/docker/chef-server.yml
+++ b/docker/chef-server.yml
@@ -48,7 +48,7 @@ services:
         hard: 65536
     volumes:
       - ${PWD}/CTL_SECRET:/hab/sup/default/CTL_SECRET
-      - elasticsearch-data:/hab/svc/elasticsearch/data
+      - elasticsearch-data:/hab/svc/elasticsearch5/data
 
   oc_id:
     image: ${CHEF_SERVER_DOCKER_ORIGIN:-chefserverofficial}/oc_id:${CHEF_SERVER_VERSION:-latest}


### PR DESCRIPTION
The provided `docker-compose` file mounts the wrong path to volume for `elasticsearch` v5 service, should be `/hab/svc/elasticsearch5/data` instead of `/hab/svc/elasticsearch/data` for the image used.