### PR TITLE
Double the max request size for erchef

### DIFF
--- a/terraform/docker-chef.sh
+++ b/terraform/docker-chef.sh
@@ -161,6 +161,8 @@ keygen_cache_workers = 2
 keygen_cache_size = 10
 keygen_start_size = 0
 keygen_timeout = 20000
+[oc_chef_wm]
+max_request_size = 2000000
 "
 oc_erchef["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind bookshelf:bookshelf.default --bind oc_bifrost:oc_bifrost.default --bind database:postgresql.default --bind elasticsearch:elasticsearch5.default --bind chef-server-ctl:chef-server-ctl.default"
 oc_erchef["gossip"]="0.0.0.0:9655"

--- a/terraform/docker-chef.sh
+++ b/terraform/docker-chef.sh
@@ -162,7 +162,7 @@ keygen_cache_size = 10
 keygen_start_size = 0
 keygen_timeout = 20000
 [oc_chef_wm]
-max_request_size = 2000000
+max_request_size = 10000000
 "
 oc_erchef["supargs"]="--peer ${HOST_IP:-172.17.0.1} --bind bookshelf:bookshelf.default --bind oc_bifrost:oc_bifrost.default --bind database:postgresql.default --bind elasticsearch:elasticsearch5.default --bind chef-server-ctl:chef-server-ctl.default"
 oc_erchef["gossip"]="0.0.0.0:9655"


### PR DESCRIPTION
Signed-off-by: Irving Popovetsky <irving@chef.io>

To help witgh `413 Request entity too large` errors, double this value by default.  Also demonstrates how to tune the setting more easily.